### PR TITLE
Allow to use animated value from screenProps

### DIFF
--- a/index.js
+++ b/index.js
@@ -295,7 +295,7 @@ export const withCollapsible = (WrappedScreen, collapsibleParams = {}) => {
     constructor(props){
       super(props);
 
-      this.scrollY = new Animated.Value(0);
+      this.scrollY = props.screenProps && props.screenProps.collapsible && props.screenProps.collapsible.scrollY || new Animated.Value(0);
       if(!collapsibleParams.extraHeader){
         this.props.navigation.setParams({
           ...createCollapsibleParams(this.scrollY),


### PR DESCRIPTION
This change allows to wrap the tab component to add dynamic tabs etc. The only additonal thing the developer has to do is to set a collapsible prop to the tabbar component:


```
class Tabs extends React.PureComponent {
  render() {
    const {collapsible} = this.props;

    const MyTabBar = createMaterialTopTabNavigator(...dynamicTabsEtc...);

    return <MyTabBar screenProps={{collapsible}} />;
  }
}

export default withCollapsilbe(Tabs);
```